### PR TITLE
Support nested paths in blob URI

### DIFF
--- a/blobfeedstorage/extensions.py
+++ b/blobfeedstorage/extensions.py
@@ -1,38 +1,35 @@
 from scrapy.extensions.feedexport import BlockingFeedStorage
-from azure.storage.blob import BlobServiceClient
-
+from azure.storage.blob import ContainerClient
+from urllib.parse import urlparse
 
 def parse_blob_uri(uri):
-    container_name = uri.split('/')[-2]
-    if not container_name.islower():
+    path = urlparse(uri).path[1:] # remove leading /
+    container_name, blob_name = path.split('/', 1) # first component is container, rest is file
+    if container_name and not container_name.islower():
         raise ValueError(f'Container name {container_name} is not valid, must be lower-case. ')
-    blob_name = uri.split('/')[-1]
     return container_name, blob_name
 
 
 class BlobFeedStorage(BlockingFeedStorage):
-
-    def __init__(self, uri, conn_str=None):
+    def __init__(self, uri, conn_str=None, overwrite=False):
+        self.overwrite = overwrite
         self.container_name, self.blob_name = parse_blob_uri(uri)
-        self.blob_service_client = BlobServiceClient.from_connection_string(conn_str)
+        
+        self.container_client = ContainerClient.from_connection_string(conn_str, self.container_name)
+        if not self.container_client.exists():
+            self.container_client.create_container()
 
     @classmethod
     def from_crawler(cls, crawler, uri):
         return cls(
             uri,
-            conn_str=crawler.settings['AZURE_STORAGE_CONN_STR']
+            conn_str=crawler.settings['AZURE_STORAGE_CONN_STR'],
+            overwrite=crawler.settings.getbool('AZURE_STORAGE_OVERWRITE')
         )
 
     def _store_in_thread(self, file):
         file.seek(0)
-        container_client = self.blob_service_client.get_container_client(self.container_name)
-        if not container_client.exists():
-            container_client.create_container()
-
-        blob_client = self.blob_service_client.get_blob_client(
-            container=self.container_name,
-            blob=self.blob_name
-        )
-        blob_client.upload_blob(file)
+        
+        self.container_client.upload_blob(self.blob_name, file, overwrite=self.overwrite)
         file.close()
 


### PR DESCRIPTION
Hey,

Thanks for making this public, the other scrapy azure feed hasn't been updated since like 2016 so much needed for sure. Just gave it a try and had to make a couple small changes for my use case so thought I'd make a PR in case you'd like to incorporate them:

1. Supporting nested paths in the blob URI. I was trying to save to `f'blob://{AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/{AZURE_STORAGE_CONTAINER}/spiders/%(name)s/batch_id_%(batch_id)d-filename_%(batch_time)s.json':` (using `FEED_EXPORT_BATCH_ITEM_COUNT`) and the existing uri parser only looks at the last 2 path components, so it created a new container with the name of my spider (`%(name)s`) and saved the file in the root of the directory. Changing this to `container_name, blob_name = urlparse(uri).path[1:].split('/', 1)` should let this work for all cases.
2. Made a minor simplification to only use `ContainerClient` as it can be created from a connection string, create the container, and upload a blob by itself, which eliminates the need for the rest.
3. Added a simple setting `AZURE_STORAGE_OVERWRITE` that allows the user to control if an existing blob should be overwritten.

Thanks again for putting this together.